### PR TITLE
Fixed de.catkeys

### DIFF
--- a/CatKeysEditor/locales/de.catkeys
+++ b/CatKeysEditor/locales/de.catkeys
@@ -1,4 +1,4 @@
-﻿1	English	application/x-vnd.puckipedia-CatKeysEditor	1128537262
+1	English	application/x-vnd.puckipedia-CatKeysEditor	1128537262
 Failed to suggest translation	TranslationView		Übersetzungsvorschlag fehlgeschlagen
 Comment: 	TranslationView		Kommentar: 
 Translated:	TranslationView		Übersetzung:


### PR DESCRIPTION
For some reason there was a character in front of the "1". In DiskProbe
it say "ef bb bf".
