### PR TITLE
Fix filter bug and add tool to import translations from another catkeys file

### DIFF
--- a/shared/TranslationView.h
+++ b/shared/TranslationView.h
@@ -16,6 +16,7 @@ class TranslationStore;
 class TranslationUnit;
 
 const int32 kMsgGotUnit = 'Unit';
+const int32 kMsgImportUnit = 'IMPU';
 
 class TranslationView : public BView {
 public:
@@ -31,6 +32,7 @@ public:
 	bool				 AutomaticallyConfirm() const {
 							return mAutomaticallyConfirm; }
 	void				 SetAutomaticallyConfirm(bool);
+	void				 ImportKeys(entry_ref fileRef);
 
 private:
 	void				 _UpdateView();
@@ -71,6 +73,7 @@ private:
 	TranslationUnit		*mUnit;
 	int					 mReceivedUnits;
 	bool				 mAutomaticallyConfirm;
+	
 };
 
 #endif

--- a/shared/TranslationWindow.cpp
+++ b/shared/TranslationWindow.cpp
@@ -8,6 +8,8 @@
 #include <LayoutBuilder.h>
 #include <Message.h>
 #include <Rect.h>
+#include <MenuBar.h>
+#include <FilePanel.h>
 
 const int32 kMsgHideTranslated = 'HiTr';
 
@@ -17,9 +19,17 @@ TranslationWindow::TranslationWindow(BRect rect, uint32 mask)
 		B_AUTO_UPDATE_SIZE_LIMITS | mask)
 {
 	mView = new TranslationView();
+	BMenuBar *menuBar = new BMenuBar("menu");
+	BMenu *toolsMenu = new BMenu("Tools");
+	toolsMenu->AddItem(new BMenuItem("Import" B_UTF8_ELLIPSIS, new BMessage(kMsgImportMenuitem)));
+	menuBar->AddItem(toolsMenu);
+	
+	mImportFilePanel = new BFilePanel(B_OPEN_PANEL, NULL, NULL, B_FILE_NODE, false, new BMessage(kImportRef));
+	mImportFilePanel->SetTarget(this);
 
 	float spacing = be_control_look->DefaultItemSpacing();
 	BLayoutBuilder::Group<>(this, B_VERTICAL)
+		.Add(menuBar)
 		.AddGroup(B_HORIZONTAL, 0)
 			.Add(mView)
 			.SetInsets(spacing);
@@ -50,6 +60,20 @@ TranslationWindow::MessageReceived(BMessage *msg)
 			msg->what = B_REFS_RECEIVED;
 			be_app->PostMessage(msg);
 		}
+	}
+	else if(msg->what == kMsgImportMenuitem)
+	{
+		if(mImportFilePanel)
+			mImportFilePanel->Show();
+		return;
+	}
+	else if(msg->what == kImportRef)
+	{
+		entry_ref fileRef;
+		status_t result = msg->FindRef("refs", &fileRef);
+		if(result == B_OK)
+			mView->ImportKeys(fileRef);
+		return;
 	}
 	BWindow::MessageReceived(msg);
 }

--- a/shared/TranslationWindow.h
+++ b/shared/TranslationWindow.h
@@ -6,6 +6,8 @@
 class TranslationView;
 
 const int32 kMsgWindowClosed = 'WINC';
+const int32 kMsgImportMenuitem = 'IMPM';
+const int32 kImportRef = 'IMPR';
 
 class TranslationWindow : public BWindow {
 public:
@@ -17,6 +19,7 @@ public:
 
 private:
 	TranslationView	*mView;
+	BFilePanel		*mImportFilePanel;
 };
 
 #endif


### PR DESCRIPTION
Hi Puckipedia, I hope you will consider adding this feature.  This should make it much easier to update catkey files that you already have other translations for.  The way I used this is I created a new en.catkeys file after making changes to translations in my app.  Then I copied en.catkeys to de.catkeys to create a new german catalog, opened it in my modified CatKeysEditor and imported the previous de.catkeys file which had most of the translations I needed.  Now all I need to do is add new translations for new text, or manually alter existing translation that didn't get imported because of some slight changes.

I match both the source and context for each translation unit when importing.

Also included is a fix for my #20 issue report.  @humdingerb you may also be interested in this tool which should accomplish in maybe a different way what you posted in issue #17.
